### PR TITLE
1034 - file size is not an issue

### DIFF
--- a/RFCs/FS-1034-fsharp-core-package.md
+++ b/RFCs/FS-1034-fsharp-core-package.md
@@ -263,6 +263,13 @@ There are many others - searching github for ``nuget FSharp.Core`` in ``paket.de
   - Response:  No! See reasons above for  why this is not sensible - there are just too many scenarios where is it is just "way simpler and much easier" to instruct
     users to reference this package.
 
+## Notes
+
+* file size [more info and some stats](https://github.com/fsharp/fslang-design/pull/201), the 8MB nupkg is:
+  - the 6.5% of .net core sdk bundle, and 0.28% of VS local nupkg feed
+  - big (3-4 times) for a single library package
+
+
 ## Acknowledgements
 
 Thanks to Enrico Sada, Steffen Forkmann, Kevin Ransom, Phillip Carter for discussions leading up to the first draft of this RFC.


### PR DESCRIPTION
> The package is now relatively large (68MB on disk unzipped) due to the large number of variations, and may get bigger (E.g. embedded PDBs)

I dont think this is correct.

there are two things:

- nupkg compressed size: 7MB
- nupkg uncompressed size: 41.7MB (size and size on disk)

But there are also differnt things:

- bundles (VS/cli/Mono) ship the nupkg compressed, and put that in a directory, used as nuget local feed.

## local feed

The sdk and MS VS (check your `C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\` ) just add a directory of nuget package used as local feed. So compressed nupkg.

Cli on first use populate the local nuget cache, VS does that when a restore is needed (afaik)

My local VS nuget feed directory is 2.5GB. and FSharp.Core there is just 6,87MB (i added that for my offline scenario). There are 511 distinct package, with multiple version usually.

| Packages     | Size        | Count (by id) |
|-|-:|-:|
| Total            | 2500MB | 511 |
| Fsharp.Core |       7MB | 1 |

As a note, **i have there (not added by myself) multiple packages not owned by MS**, like `BundlerMinifier.Core`, `SQLite`, `SQLite.Native`, `Serilog.*` (5), `Remotion.Linq`, `Owin`, `StackExchange.Redis.StrongName`.
Who added these? dunno, but work for offline scenario

> * The package is not pre-installed with tooling (preventing some offline development scenarios)

because maybe can be done with the local feed. with package not owned by MS.


## local nuget cache

When the package is used, is restored in the local nuget cache. 

My directory in nuget cache for `Fsharp.Core` (`C:\Users\e.sada\.nuget\packages\FSharp.Core`) is 357MB and contains 13 version of Fsharp.Core (from 2.0.0, 3.0.2, ..., 4.1.17 ) 
My local nuget cache total size

| Packages     | Size        | Size (GB) | Count (by id) | Count (by version) |
|-|-:|-:|-:|-:|
| Total            | 40000MB| 40,0GB |1074 | dunno |
| Fsharp.Core |       357MB | 0,3GB | 1 | 13 |

