### PR TITLE
Update FST-1005 for new requirements for Microsoft employees

### DIFF
--- a/tooling/FST-1005-package-signing.md
+++ b/tooling/FST-1005-package-signing.md
@@ -1,16 +1,22 @@
-# FS-1005 Package Signing
+# FS-1005 Package Authoring for Microsoft co-owned packages
 
-This is inspired by [this PR](https://github.com/Microsoft/visualfsharp/pull/4734).
+As per the requirements by Microsoft's Developer Division, all NuGet packages which are developed and distributed by Microsoft (including if they are co-owned) must be adhere to the following:
 
-As per the requirements by Microsoft's Developer Division, all NuGet packages which are developed and distributed by Microsoft (including if they are co-owned) must be signed with Microsoft's signing keys. This includes the following packages:
+* Co-owned on [nuget.org](https://www.nuget.org/) by the [Microsoft](https://www.nuget.org/profiles/microsoft) and [fsharporg](https://www.nuget.org/profiles/fsharporg) organizations.
+* Binary is signed with Microsoft signing keys.
+* Package itself is signed with Microsoft signing keys.
+* The following package authoring:
+    * **Author** includes "Microsoft".
+    * **Owner** includes "Microsoft".
+    * **Copyright** is "© Microsoft Corporation. All rights reserved"
+
+The following packages will follow this:
 
 * FSharp.Core
 
-(The list is short right now, but should we start publishing other `FSharp.*` packages, this list would update)
-
 ## What does this mean?
 
-The binaries in the above-mentioned packages are already signed by Microsoft. This means that the packages themselves are signed as well.
+This is effectively Microsoft getting their ducks in row. That is, the days of publishing with person accounts (e.g., "dsyme", "kevinransom") are no longer allowed. If a package is authored or co-authored by a Microsoft team, it must be presented as "Microsoft" and not an individual account for a given employee.
 
 ## What does this not mean?
 
@@ -20,4 +26,4 @@ Any of the following do not apply:
 * Removing ability of F# Software Foundation to manage the above projects in conjunction with Microsoft
 * Removing of any existing permissions or capabilities for the F# Software Foundation
 
-In short, the existing relationship between Microsoft and FSSF as far as package ownership goes remains the same: Microsoft and the FSSF are co-owners of the above packages.
+In short, the existing relationship between Microsoft and FSSF as far as package ownership goes remains the same: Microsoft and the FSSF are co-owners of the above packages, and both maintain the rights to manage assets.


### PR DESCRIPTION
There is a new policy for Microsoft employees w.r.t publishing assets to NuGet. This is really just about cleaning things up on our end. This does not affect the F# Software Foundation's ownership of various packages.