### PR TITLE
Fix typo for F# language version

### DIFF
--- a/tooling/FST-1004-versioning-plan.md
+++ b/tooling/FST-1004-versioning-plan.md
@@ -13,7 +13,7 @@ We have strong motivation to decouple versioning of the F# compiler and tools fr
 
 | Visual Studio version | 15.5 (current) | 15.6 | 15.7 | 15.8 | vNext |
 |------------|----------:|-----:|------:|------:|------:|
-| **F# language version** | 4.1 | 4.1 | 4.1 | 4.5 | 4.x |
+| **F# language version** | 4.1 | 4.1 | 4.1 | 4.5 | 4.n |
 | **FSharp.Core version** | 4.4.1.0 | 4.4.3.w | 4.4.3.w | 4.5.w.0 | 4.n.w.0 |
 | **FSharp.Core NuGet package version** | 4.2.x | 4.3.x | 4.3.x | 4.5.x | 4.n.x |
 | **F# compiler banner** | F# Compiler 4.1 | F# Compiler 10.0.a for F# 4.1 | F# Compiler 10.1.a for F# 4.1 |F# Compiler 10.2.b for F# 4.5 | F# Compiler XX.a.b for F# 4.n |


### PR DESCRIPTION
I believe this should have been 4.n as per the lines below.