### PR TITLE
[WIP] additions to RFC FS-1070

### DIFF
--- a/RFCs/FS-1070-offside-relaxations.md
+++ b/RFCs/FS-1070-offside-relaxations.md
@@ -1,4 +1,4 @@
-# F# RFC FS-1070 - Offside relaxations for constructors and members
+# F# RFC FS-1070 - Offside relaxations for function/constructor/member definitions
 
 The design suggestion [Allow undentation for constructors](https://github.com/fsharp/fslang-suggestions/issues/724) has been marked "approved in principle".
 This RFC covers the detailed proposal for this suggestion and some related design relaxations.
@@ -11,30 +11,54 @@ This RFC covers the detailed proposal for this suggestion and some related desig
 # Summary
 [summary]: #summary
 
-F#'s indentation rules are overly stringent for the argument lists of implicit constructors and static methods. This relaxs the
+F#'s indentation rules are overly stringent for the argument lists of functions, implicit constructors, and static methods. This RFC relaxes the
 rules for these cases by adding some permitted "undentations".
 
-#### Code Examples
+## Code Examples
 
-For example, currently these all give a indentation warnings:
+Currently these all give the indentation warning `FS0058 Possible incorrect indentation: this token is offside...`:
+
+```fsharp
+let f(a:int,
+    b:int, c:int, // warning
+    d:int) =
+```
+and:
 ```fsharp
 type OffsideCheck(a:int,
-        b:int, c:int,  // warning offside of '('
+        b:int, c:int, // warning
         d:int) =
 ```
 and:
 ```fsharp
-type OffsideCheck(a:int,
-   b:int, c:int,  // warning offside of '('
-   d:int) =
-```
-and:
-```fsharp
     static member M(a:int,
-        b:int, c:int, // warning offside of 'member'
+        b:int, c:int, // warning
         d:int) = 1
 ```
-and:
+
+In each case `a` sets the offside line and `b` needs to be aligned with `a` to avoid the warning.
+
+Allowing undentation in these three cases would remove the warning.
+
+It would also allow 
+
+```fsharp
+let f(
+    a:int, // warning: `a` needs to be aligned with or after `(`.
+    b:int, c:int) =
+
+type OffsideCheck(
+        a:int, // warning: `a` needs to be aligned with or after `(`.
+        b:int, c:int) =
+    static member M(
+        a:int,
+        b:int, c:int, // warning: `a` needs to be aligned after `(`.
+        d:int) = 1
+```
+
+#### Possibly related: `with get` and `with set`
+The following example may also be relaxed:
+
 ```fsharp
 type C() = 
     static member P with get() = 
@@ -43,10 +67,14 @@ type C() =
 In all the above cases an andentation is added.
 
 
-#### Detailed Design
+## Detailed Design
 
-TBD. Each newly permitted undenation is declarative in the implementation, and
-simply needs to be translated into the terminology used in the F# language spec.
+Function definitions, constructor definitions, and member definitions taking inputs, should be added to the list of permitted undentations in the F# language spec.
+Undentation when applying functions, and when defining curried functions, is already possible but should be added to the spec to confirm this.
+
+In the language of the spec, the undentation is premitted from the bracket starting a sequence of arguments in a definition, but the block must not undent past other offside lines.
+
+One example from the examples above will suffice to add to the spec.
 
 ## Code samples
 


### PR DESCRIPTION
Completing RFC FS-1070 (undentation of constructors etc.).

This is broadened to include function definitions with uncurried arguments, as these are obviously very similar to constructor and member definitions with the same argument structure.

I moved some code into "Possibly related: with get and with set" and I'm not sure how exactly this connects to the rest of the proposal, or what the best spec should be for this. This needs to be decided before merging this PR.