### PR TITLE
Use `member` and not `override` for default interface members.

### DIFF
--- a/RFCs/FS-1074-default-interface-member-inteop.md
+++ b/RFCs/FS-1074-default-interface-member-inteop.md
@@ -85,14 +85,14 @@ open Dims
 
 type C() =
     interface IHaveADefaultMember with
-        override __.GetNumber() = 13
+        member __.GetNumber() = 13
 
 let i = C() :> IHaveADefaultMember
 printfn "%d" i.GetNumber() // 13
 
 let i' =
     { new IHaveADefaultMember
-        override __.GetNumber() = 13 }
+        member __.GetNumber() = 13 }
 printfn "%d" i'.GetNumber() // 13
 ```
 


### PR DESCRIPTION
C# has refrained from using the `override` word to describe overriding an interface member implementation. We should do the same.

Also, in F#, you can already override an interface member implementation if you inherited from a class that contains the implementation for a interface member, simply using `member __.(memberName)`.

For example, you can already do this today:
```fsharp
type ITest =

    abstract member A: int

    abstract member B: int

type TestClass1 () =

    interface ITest with
        
        member __.A = 5

        member __.B = 6

type TestClass2 () =
    inherit TestClass1 ()

    interface ITest with

        member __.A = 10

[<EntryPoint>]
let main _ =
    let test1 = TestClass1 () :> ITest
    let test2 = TestClass2 () :> ITest

    printfn "%i" test1.A
    printfn "%i" test2.A
    0
```

Prints:
```
5
10
```