### PR TITLE
From the end slicing for collections

### DIFF
--- a/RFCs/FS-1076-from-the-end-slicing.md
+++ b/RFCs/FS-1076-from-the-end-slicing.md
@@ -1,0 +1,86 @@
+# F# RFC FS-1076 - From the end slicing for collections
+
+The design suggestion [FILL ME IN](https://github.com/fsharp/fslang-suggestions/issues/fill-me-in) has been marked "approved in principle".
+This RFC covers the detailed proposal for this suggestion.
+
+* [x] Approved in principle
+* [ ] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/fill-me-in)
+* [ ] Details: [under discussion](https://github.com/fsharp/fslang-design/issues/FILL-ME-IN)
+* [ ] Implementation: [In progress](https://github.com/Microsoft/visualfsharp/pull/FILL-ME-IN)
+
+
+# Summary
+[summary]: #summary
+
+This RFC proposes the capability to slice collections with indices counted from the end. Using the `^i` syntax in slicing is equivalent to `(List.length myList) - i`.
+
+e.g.
+```
+let list = [1;2;3;4;5]
+
+list.[..^0]   // 1,2,3,4,5
+list.[..^1]   // 1,2,3,4
+list.[0..^1]  // 1,2,3,4
+list.[^1..]   // 4,5
+list.[^0..]   // 5
+list.[^2..^1] // 3,4
+```
+
+# Motivation
+[motivation]: #motivation
+
+From-the-end slicing would allow easier operations on arrays. Currently in Python one can specify a negative index, like `list.[:-1]` to obtain a slice of the list without the last element. This feature is often used in scientific and mathematical computation. Adding this feature would make F# more accessible for those uses.
+
+# Detailed design
+[design]: #detailed-design
+
+## Parsing
+
+We add new rules to the parser to support the following expressions
+```
+^x..y
+^x..
+x..^y
+..^y
+^x..^y
+```
+
+## Typechecker
+
+
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
+with the language to understand, and for somebody familiar with the compiler to implement.
+This should get into specifics and corner-cases, and include examples of how the feature is used.
+
+Example code:
+
+```fsharp
+let add x y = x + y
+```
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Alternatives
+[alternatives]: #alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+# Compatibility
+[compatibility]: #compatibility
+
+Please address all necessary compatibility questions:
+* Is this a breaking change?
+* What happens when previous versions of the F# compiler encounter this design addition as source code?
+* What happens when previous versions of the F# compiler encounter this design addition in compiled binaries?
+* If this is a change or extension to FSharp.Core, what happens when previous versions of the F# compiler encounter this construct?
+
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+What parts of the design are still TBD?
+

--- a/RFCs/FS-1076-from-the-end-slicing.md
+++ b/RFCs/FS-1076-from-the-end-slicing.md
@@ -1,10 +1,9 @@
 # F# RFC FS-1076 - From the end slicing for collections
 
-The design suggestion [FILL ME IN](https://github.com/fsharp/fslang-suggestions/issues/fill-me-in) has been marked "approved in principle".
 This RFC covers the detailed proposal for this suggestion.
 
-* [x] Approved in principle
-* [ ] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/fill-me-in)
+* [ ] Approved in principle
+* [ ] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/358)
 * [ ] Details: [under discussion](https://github.com/fsharp/fslang-design/issues/FILL-ME-IN)
 * [ ] Implementation: [In progress](https://github.com/Microsoft/visualfsharp/pull/FILL-ME-IN)
 

--- a/RFCs/FS-1076-from-the-end-slicing.md
+++ b/RFCs/FS-1076-from-the-end-slicing.md
@@ -12,7 +12,7 @@ This RFC covers the detailed proposal for this suggestion.
 # Summary
 [summary]: #summary
 
-This RFC proposes the capability to slice collections with indices counted from the end. Using the `^i` syntax in slicing is equivalent to `(List.length myList) - i`.
+This RFC proposes the capability to slice collections with indices counted from the end. Using the `^i` syntax in slicing desugars to `myList.Length - i - 1`.
 
 e.g.
 ```
@@ -36,7 +36,17 @@ From-the-end slicing would allow easier operations on arrays. Currently in Pytho
 
 ## Parsing
 
-We add new rules to the parser to support the following expressions
+The `^` operator is currently used as a infix operator for:
+- Power (2^2)
+- Measure types
+- Legacy string concat
+
+It is used as a prefix operator for:
+- Statically resolved types
+
+For the from-the-end slicing, the `^` operator will be overloaded as a prefix operator. 
+
+We will add new rules to the parser to support the following expressions for `optRange`:
 ```
 ^x..y
 ^x..
@@ -47,40 +57,64 @@ x..^y
 
 ## Typechecker
 
+Currently in the typechecker, the slicing is handled in two ways (see `typechecker.fs: 6295`):
+
+- For core collections, depending on the shape of the slicing call and the type of the collection, the appropriate `GetSlice` method implementation is picked and the supplied slicing indices are transformed into arguments to those methods.
+- For third party collections, the compiler builds a generic `GetSlice` call, then does another round of typechecking to find the concrete implementation.
 
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
-with the language to understand, and for somebody familiar with the compiler to implement.
-This should get into specifics and corner-cases, and include examples of how the feature is used.
-
-Example code:
-
-```fsharp
-let add x y = x + y
-```
+To support from-the-end slicing, logic can be added in these two code paths to check if the `^` symbol was prepended to any of the indices. If it is detected, the call to `GetSlice` with the index `^i` will be desugared to `myList.Length - i - 1`. The desugared indices will be piped to the existing `GetSlice` implementations.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-Why should we *not* do this?
+## Differing behavior with current inclusive-inclusive slicing compared to other languages
+
+The current F# slicing behavior is front-inclusive and rear-inclusive, in contrast to front-inclusive and rear-exclusive for C# and Python. This means that if we choose to desugar `^i` to `myList.Length - i - 1`, then:
+
+```
+// Python
+list[:-1]    // 1,2,3,4
+list[-1:]    // 5
+
+// F#
+list.[..^1]  // 1,2,3,4 -- Same
+list.[^1..]  // 4,5     -- Different
+list.[^0..]  // 5       -- Different
+```
+
+Because of the difference in inclusivity, we can only match Python/C# behavior for either `list.[^1..]` or `list.[..^1]` but not both, unless the definition of `^i` varies based on the context of where it's placed. 
+
+It is assumed that most users will use this syntax in the form of `list.[..^1]`, or "I want everything in this except for the last i elements."
 
 # Alternatives
 [alternatives]: #alternatives
 
-What other designs have been considered? What is the impact of not doing this?
+- Using `-` instead of `^`: not possible since negative indexes can be valid
+- Defining `^i` as `mylist.Length - i` without the `-1`. This would allow `list[-1:] == list.[^1..]` but would cause `list.[..^1]` to be different.
+- Define `^i` to mean `mylist.Length - i` if used as the starting index of a slice and `mylist.Length - i - 1` if used as the end index. This would align the behavior completely with C#, but it would mean that the slicing would change from inclusive-inclusive to inclusive-exclusive if the `^` operator was used.
 
 # Compatibility
 [compatibility]: #compatibility
 
 Please address all necessary compatibility questions:
-* Is this a breaking change?
-* What happens when previous versions of the F# compiler encounter this design addition as source code?
-* What happens when previous versions of the F# compiler encounter this design addition in compiled binaries?
-* If this is a change or extension to FSharp.Core, what happens when previous versions of the F# compiler encounter this construct?
+* Is this a breaking change? **No**
 
+## Third-party collections
+
+We currently require third party collections to implement `<'T>.GetSlice` to support slicing syntax. We can additionally require third party collections to implement `<'T>.Length` if they wish to support from-the-end slicing. If they choose to do only the former, any `^i` indices in the slice will fail with runtime error trying to resolve `<'T>.Length`.
+
+## Old versions of Core
+- New compiler + new core:
+    - Expected behavior
+- New compiler + old core:
+    - Same behavior as above, as the `^i` is desugared into a normal `GetSlice` call.
+- Old compiler + new core:
+    - Error on `^` at compile time.
+- Old compiler + old core:
+    - Error on `^` at compile time.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-What parts of the design are still TBD?
-
+Do we have actual data to back up the assumption that people use the `list.[..^1]` more than `list.[^1..]`?

--- a/RFCs/FS-1076-from-the-end-slicing.md
+++ b/RFCs/FS-1076-from-the-end-slicing.md
@@ -11,7 +11,7 @@ This RFC covers the detailed proposal for this suggestion.
 # Summary
 [summary]: #summary
 
-This RFC proposes the capability to slice collections with indices counted from the end. Using the `^i` syntax in slicing desugars to `myList.Length - i - 1`.
+This RFC proposes the capability to slice collections with indices counted from the end. Using the `^i` syntax in slicing desugars to `collection.GetReverseIndex(i)`.
 
 e.g.
 ```
@@ -54,6 +54,10 @@ x..^y
 ^x..^y
 ```
 
+Using `^` outside of the square brackets will not mean anything, as the parsing rule that handles it only exists inside `optRange`.
+
+In addition, because of the way `..` is handled currently in the lexer, to correctly parse `..^`, we would have to add it to the list of reserved symbolic operators. This would break any users currently using `..^` as a custom operator.
+
 ## Typechecker
 
 Currently in the typechecker, the slicing is handled in two ways (see `typechecker.fs: 6295`):
@@ -62,14 +66,20 @@ Currently in the typechecker, the slicing is handled in two ways (see `typecheck
 - For third party collections, the compiler builds a generic `GetSlice` call, then does another round of typechecking to find the concrete implementation.
 
 
-To support from-the-end slicing, logic can be added in these two code paths to check if the `^` symbol was prepended to any of the indices. If it is detected, the call to `GetSlice` with the index `^i` will be desugared to `myList.Length - i - 1`. The desugared indices will be piped to the existing `GetSlice` implementations.
+To support from-the-end slicing, logic can be added in these two code paths to check if the `^` symbol was prepended to any of the indices. If it is detected, the call to `GetSlice` with the index `^i` will be desugared to `myCollection.GetReverseIndex(i)`. The desugared indices will be piped to the existing `GetSlice` implementations.
+
+For all the core collections, the provided implementation of `GetReverseIndex(i)` would be `collection.Length - i - 1` (See below for rationale of -1).
+
+For third party collections, a `GetReverseIndex` method would need to exist for the `^` to work correctly. If `GetSlice` is implemented and `GetReverseIndex` is not, regular slicing would function as expected, but when `^` is present in the slice expression there would be an error thrown at compile time that looks like `GetReverseIndex is not defined`.
+
+A `GetReverseIndex` is not implemented by default for third party collections because we do not know if the third party collection has a concept of `collection.Length`. 
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 ## Differing behavior with current inclusive-inclusive slicing compared to other languages
 
-The current F# slicing behavior is front-inclusive and rear-inclusive, in contrast to front-inclusive and rear-exclusive for C# and Python. This means that if we choose to desugar `^i` to `myList.Length - i - 1`, then:
+The current F# slicing behavior is front-inclusive and rear-inclusive, in contrast to front-inclusive and rear-exclusive for C# and Python. This means that if we choose to implement `GetReverseIndex(i)` as `myList.Length - i - 1`, then:
 
 ```
 // Python
@@ -86,22 +96,31 @@ Because of the difference in inclusivity, we can only match Python/C# behavior f
 
 It is assumed that most users will use this syntax in the form of `list.[..^1]`, or "I want everything in this except for the last i elements."
 
+## Third party collections could implement reverse slicing in an inconsistent way
+
+Because `GetReverseIndex` needs to be implemented by third party collections, they could implement it in a way that is inconsistent with the proposed behavior in Core. For example, if a third party author decides to implement `GetReverseIndex(i)` as `arr.Length - i` without the `-1`, this would result in different behavior compared to core collections.
+
+If a user is using the third party collection alongside core collections, this would be very confusing as `collection.[..^1]` could return different elements even if the two collections contain the same items.
+
 # Alternatives
 [alternatives]: #alternatives
 
 - Using `-` instead of `^`: not possible since negative indexes can be valid
 - Defining `^i` as `mylist.Length - i` without the `-1`. This would allow `list[-1:] == list.[^1..]` but would cause `list.[..^1]` to be different.
 - Define `^i` to mean `mylist.Length - i` if used as the starting index of a slice and `mylist.Length - i - 1` if used as the end index. This would align the behavior completely with C#, but it would mean that the slicing would change from inclusive-inclusive to inclusive-exclusive if the `^` operator was used.
+- Providing a default `GetReverseIndex` for third party collections.
 
 # Compatibility
 [compatibility]: #compatibility
 
 Please address all necessary compatibility questions:
-* Is this a breaking change? **No**
+* Is this a breaking change? **Yes**
+
+This would break any code that defines `..^` as a custom operator.
 
 ## Third-party collections
 
-We currently require third party collections to implement `<'T>.GetSlice` to support slicing syntax. We can additionally require third party collections to implement `<'T>.Length` if they wish to support from-the-end slicing. If they choose to do only the former, any `^i` indices in the slice will fail with runtime error trying to resolve `<'T>.Length`.
+We currently require third party collections to implement `<'T>.GetSlice` to support slicing syntax. We can additionally require third party collections to implement `<'T>.GetReverseIndex` if they wish to support from-the-end slicing. If they choose to do only the former, any `^i` indices in the slice will fail with a compile time error.
 
 ## Old versions of Core
 - New compiler + new core:


### PR DESCRIPTION
This RFC proposes the addition of the `^` symbol in the current slicing syntax to index slices from the end of a collection.