### PR TITLE
Update the custom attribute code in FS-1053-span.md.

### DIFF
--- a/FSharp-4.5/FS-1053-span.md
+++ b/FSharp-4.5/FS-1053-span.md
@@ -570,20 +570,21 @@ type DateTime with
 ```
 This makes it impossible to define byref extension properties in particular. 
 
-* Note that `IsByRefLikeAttribute` is only available in .NET 4.7.2.
+* Note that `IsByRefLikeAttribute` is only available in at least .NET 4.7.2 or .NET Standard 2.1.
+
+Those who are targeting other frameworks can define these attributes in their own code this way:
 
 ```fsharp
 namespace System.Runtime.CompilerServices
     open System
-    open System.Runtime.CompilerServices
-    open System.Runtime.InteropServices
-    [<AttributeUsage(AttributeTargets.All,AllowMultiple=false); Sealed>]
-    type IsReadOnlyAttribute() =
-        inherit System.Attribute()
 
-    [<AttributeUsage(AttributeTargets.All,AllowMultiple=false); Sealed>]
-    type IsByRefLikeAttribute() =
-        inherit System.Attribute()
+    [<AttributeUsage(AttributeTargets.All); Sealed>]
+    type internal IsReadOnlyAttribute() =
+        inherit Attribute()
+
+    [<AttributeUsage(AttributeTargets.Struct); Sealed>]
+    type internal IsByRefLikeAttribute() =
+        inherit Attribute()
 ```
 
 


### PR DESCRIPTION
Some notes about the changes:

* It is better for the attributes to become internal, as they will pollute the public API of a library. This is what C# does as well.
* `IsByRefLikeAttribute` is defined to be only allowed to be placed on structs.
* `AttributeUsage.AllowMultiple` is false by default.
* Some unused namespaces and fully qualified names were removed.