### PR TITLE
Renumber nameof pattern RFC to 1085 + add discussion link

### DIFF
--- a/RFCs/FS-1085-nameof-pattern.md
+++ b/RFCs/FS-1085-nameof-pattern.md
@@ -4,7 +4,7 @@ The design suggestion [Allow using nameof as a constant in pattern matching](htt
 
 * [x] Approved in principle
 * [x] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/841)
-* [ ] RFC Discussion
+* [x] [RFC Discussion](https://github.com/fsharp/fslang-design/issues/451)
 * [x] [Implementation: in progress](https://github.com/dotnet/fsharp/pull/8754)
 
 # Summary


### PR DESCRIPTION
Renumber due to clash with [RFC-1084](https://github.com/fsharp/fslang-design/pull/442).