### PR TITLE
FS-1039: Remove StructAttribute from partial active pattern definition

### DIFF
--- a/RFCs/FS-1039-struct-representation-for-active-patterns.md
+++ b/RFCs/FS-1039-struct-representation-for-active-patterns.md
@@ -40,17 +40,14 @@ let (|Int|_|) str =
    | _ -> None
 ```
 
-Put the `StructAttribute` on the active pattern definition.
+Put the `ValueSome`/`ValueNone` instead of `Some`/`None` cases.
 
 ```fsharp
-[<Struct>]
 let (|Int|_|) str =
    match System.Int32.TryParse(str) with
-   | (true,int) -> VSome(int)
-   | _ -> VNone
+   | (true,int) -> ValueSome(int)
+   | _ -> ValueNone
 ```
-
-You might to note in struct version different names of `Some`/`None` cases are used. This is because of the need to distinguish between struct and non-struct versions of the `option` type.
 
 **3. It should be possible to compile total `(|A|B|)` active patterns to use struct choices**
 


### PR DESCRIPTION
`StructAttribute` is not actually needed here. Instead we could allow partial active patterns to return both `voption` and `option`. I think this would increase code clarity.