### PR TITLE
Add RFC-1092: Support for erased union types

### DIFF
--- a/RFCs/FS-1092-Erased-Union-Types.md
+++ b/RFCs/FS-1092-Erased-Union-Types.md
@@ -39,8 +39,8 @@ type WorkManagerMessage = (RunWork | SubscribeProgressUpdate)
 
 let processWorkerMessage (msg: WorkerMessage) =
     match msg with
-    | :? RunWork -> ...
-    | :? RequestProgressUpdate -> ...
+    | :? RunWork as m -> ...
+    | :? RequestProgressUpdate m -> ...
 ```
 
 ```fsharp
@@ -127,8 +127,21 @@ TBD
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-* Initial implementation should not allow for using uom in erased unions?
+
+* Initial implementation should not allow for using uom in erased unions? 
+
+    ```fsharp
+    type [<Measure>] userid
+    type UserId = int<userid>
+    type IntOrUserId = (int|UserId)
+    ```
+
 * Initial implementation should not allow using generic type arguments in erased unions?
+
+    ```fsharp
+    type StringOr<'a> = ('a | string)
+    ```
+
 * Initial implementation should not allow for common members of the erased unions to be exposed without upcasting?
 
     ```fsharp
@@ -150,3 +163,4 @@ TBD
     let what = shape.What // error
     let what = (shape :> IShape).What // ok
     ```
+* Should exhaustive check in instance check be implemented across normal circumstances? https://github.com/dotnet/fsharp/issues/10615

--- a/RFCs/FS-1092-Erased-Union-Types.md
+++ b/RFCs/FS-1092-Erased-Union-Types.md
@@ -1,0 +1,152 @@
+# F# RFC FS-1092 - Erased Union Types
+
+This RFC covers the detailed proposal for this suggestion. [Erased type-tagged anonymous union types](https://github.com/fsharp/fslang-suggestions/issues/538).
+
+* [ ] Approved in principle
+* [x] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/538)
+* [ ] Details: TBD
+* [ ] Implementation: [Preliminary Prototype](https://github.com/dotnet/fsharp/pull/10566)
+
+
+# Summary
+[summary]: #summary
+
+Add erased union types as a feature to F#. Erased Union types provide some of the benefits of structural ("duck") typing, within the confines of a nominative type system.
+
+# Motivation
+[motivation]: #motivation
+
+Supporting erased union types in the language allows us to move more type information with the usual advantages this brings:
+
+* They serve as an alternative to function overloading.
+* They obey subtyping rules.
+* They allow representing subset of protocols as a type without needing to resort to the lowest common denominator like `obj`.
+* Types are actually enforced, so mistakes can be caught early.
+* They allow representing more than one type
+* Because they are enforced, type information is less likely to become outdated or miss edge-cases.
+* Types are checked during inheritance, enforcing the Liskov Substitution Principle.
+
+```fsharp
+let distance(x: (Point|Location), y: (Point|Location)) = ...
+```
+
+```fsharp
+type RunWork = RunWork of args: string
+type RequestProgressUpdate = RequestProgressUpdate of workId: int
+type SubscribeProgressUpdate = SubscribeProgressUpdate of receiver: string
+type WorkerMessage = (RunWork | RequestProgressUpdate)
+type WorkManagerMessage = (RunWork | SubscribeProgressUpdate)
+
+let processWorkerMessage (msg: WorkerMessage) =
+    match msg with
+    | :? RunWork -> ...
+    | :? RequestProgressUpdate -> ...
+```
+
+```fsharp
+type Username = Username of string
+type Password = Password of string
+type UserOrPass = (Password | UserName)
+
+// userOrPass binding is inferred to UserOrPass type
+let userOrPass = if (true) name :> UserOrPass else password :> UserOrPass
+```
+
+# Detailed design
+[design]: #detailed-design
+
+## Subtyping rules
+[subtyping]: #subtyping-rules
+
+* Erased union are commutative and associative:
+
+    ```fsharp
+    (A | B) =:= (B | A)
+    (A | (B | C)) =:= (( A | B ) | C)
+    ```
+
+    *`=:=` implies type equality and interchangable in all context*
+
+* If `A :> C` and `B :> C` then `(A | B) :> C` where `T :> U` implicies T is subtype of C;
+
+## Type inference
+[inference]: #type-inference
+
+Erased Union type is explicitly inferred meaning that at least one of the type in an expression must contain the erased union type.
+
+i.e something like the following is invalid:
+
+```fsharp
+let intOrString = if true then 1 else "Hello" // invalid
+```
+
+However the following is valid:
+
+```fsharp
+// inferred to (int|string)
+let intOrString = if true then 1 :> (int|string) else "Hello" :> _  invalid
+```
+
+This respects the rules around where explicit upcasting is required including cases despite where type information being available. Although the later might change depending on the outcome of [fslang-suggestion#849](https://github.com/fsharp/fslang-suggestions/issues/849)
+
+## Exhaustivity checking
+[exhaustivity]: #exhaustivity-checking
+
+If the selector of a pattern match is an erased union type, the match is considered exhaustive if all parts of the erased union are covered. There would be no need for fallback switch.
+
+```fsharp
+let prettyPrint (x: (int8|int16|int64|string)) =
+    match x with
+    | :? (int8|int16|int64) as y -> prettyPrintNumber y
+    | :? string as y -> prettyPrintNumber y
+```
+
+Similarly the following would also be considered exhaustive:
+```fsharp
+let prettyPrint (x: (int8|int16|int64|string)) =
+    match x with
+    | :? System.ValueType as y -> prettyPrintNumber y // int8, int16 and int64 are subtype of ValueType
+    | :? string as y -> prettyPrintNumber y
+```
+
+## Erased Type
+
+The erased type for `(A | B)` is the _smallest intersection type_ of base
+types of `A` and `B`.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+TBD
+
+# Alternatives
+[alternatives]: #alternatives
+
+TBD
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+* Initial implementation should not allow for using uom in erased unions?
+* Initial implementation should not allow using generic type arguments in erased unions?
+* Initial implementation should not allow for common members of the erased unions to be exposed without upcasting?
+
+    ```fsharp
+    type IShape =
+        abstract member What: string
+
+    type Circle =
+        | Circle of r: float
+        interface IShape with
+            member _.What = "Circle"
+
+    type Square =
+        | Square of l: float
+        interface IShape with
+            member _.What = "Square"
+
+    /// example
+    let shape = Circle(1.0) :> (Circle | Square) // erased type IShape
+    let what = shape.What // error
+    let what = (shape :> IShape).What // ok
+    ```

--- a/RFCs/FS-1092-Erased-Union-Types.md
+++ b/RFCs/FS-1092-Erased-Union-Types.md
@@ -84,7 +84,7 @@ However the following is valid:
 
 ```fsharp
 // inferred to (int|string)
-let intOrString = if true then 1 :> (int|string) else "Hello" :> _  invalid
+let intOrString = if true then 1 :> (int|string) else "Hello" :> _ 
 ```
 
 This respects the rules around where explicit upcasting is required including cases despite where type information being available. Although the later might change depending on the outcome of [fslang-suggestion#849](https://github.com/fsharp/fslang-suggestions/issues/849)

--- a/RFCs/FS-1092-Erased-Union-Types.md
+++ b/RFCs/FS-1092-Erased-Union-Types.md
@@ -128,13 +128,15 @@ TBD
 [unresolved]: #unresolved-questions
 
 
-* Initial implementation should not allow for using uom in erased unions? 
+* Initial implementation should not allow for using uom in erased unions when the underlying primitive is already part of union? 
 
     ```fsharp
     type [<Measure>] userid
     type UserId = int<userid>
     type IntOrUserId = (int|UserId)
     ```
+
+    Alternatively we could just warn when such constructs are used.
 
 * Initial implementation should not allow using generic type arguments in erased unions?
 
@@ -163,4 +165,5 @@ TBD
     let what = shape.What // error
     let what = (shape :> IShape).What // ok
     ```
-* Should exhaustive check in instance check be implemented across normal circumstances? https://github.com/dotnet/fsharp/issues/10615
+
+* Should exhaustive check in instance clause be implemented in normal circumstances? https://github.com/dotnet/fsharp/issues/10615

--- a/RFCs/FS-1092-Erased-Union-Types.md
+++ b/RFCs/FS-1092-Erased-Union-Types.md
@@ -70,7 +70,7 @@ let getUserOrPass2 () = if isErr() then err :> (UserOrPass | Error) else getUser
 
     *`=:=` implies type equality and interchangable in all context*
 
-* If `A :> C` and `B :> C` then `(A | B) :> C` where `T :> U` implicies T is subtype of C;
+* If `A :> C` and `B :> C` then `(A | B) :> C` where `T :> U` implies T is subtype of C;
 
 ### Hierarchies in Types
 [hierarchy]: #hierarchy-types
@@ -102,7 +102,7 @@ type (A|C)   // disjoint as A and C both inherit from I but do not have relation
 ## Type inference
 [inference]: #type-inference
 
-Erased Union type is explicitly inferred meaning that at least one of the type in an expression must contain the erased union type.
+Erased Union type is explicitly inferred meaning that at least one of the types in an expression must contain the erased union type.
 
 i.e something like the following is invalid:
 
@@ -117,7 +117,7 @@ However the following is valid:
 let intOrString = if true then 1 :> (int|string) else "Hello" :> _
 ```
 
-This respects the rules around where explicit upcasting is required including cases despite where type information being available. Although the later might change depending on the outcome of [fslang-suggestion#849](https://github.com/fsharp/fslang-suggestions/issues/849)
+This respects the rules around where explicit upcasting is required including cases despite where type information being available. Although the latter might change depending on the outcome of [fslang-suggestion#849](https://github.com/fsharp/fslang-suggestions/issues/849)
 
 ## Exhaustivity checking
 [exhaustivity]: #exhaustivity-checking

--- a/RFCs/FS-1092-Erased-Union-Types.md
+++ b/RFCs/FS-1092-Erased-Union-Types.md
@@ -72,6 +72,33 @@ let getUserOrPass2 () = if isErr() then err :> (UserOrPass | Error) else getUser
 
 * If `A :> C` and `B :> C` then `(A | B) :> C` where `T :> U` implicies T is subtype of C;
 
+### Hierarchies in Types
+[hierarchy]: #hierarchy-types
+
+For cases where, all cases in the union are disjoint, all cases must be exhaustively checked during pattern matching.
+However in situations where one of the case is a supertype of another case, the super type is chosen discarding the derived cases.
+
+For example:
+`I` is the base class, which class `A` and class `B` derives from. `C` and `D` subsequently derives from `B`
+
+```fsharp
+   ┌───┐
+   │ I │
+   └─┬─┘
+  ┌──┴───┐
+┌─┴─┐  ┌─┴─┐
+│ A │  │ B │
+└───┘  └─┬─┘
+      ┌──┴───┐
+    ┌─┴─┐  ┌─┴─┐
+    │ C │  │ D │
+    └───┘  └───┘
+
+type (A|B|I) // equal to type definition for I, since I is supertype of A and B
+type (A|B|C) // equal to type (A|B), since B is supertype of C
+type (A|C)   // disjoint as A and C both inherit from I but do not have relationship between each other.
+```
+
 ## Type inference
 [inference]: #type-inference
 
@@ -144,23 +171,6 @@ type C = inherit I inherit I2
 type D = inherit I inherit I2
 // Both I or I2 could be potential wrapping type. The compiler would choose I2 since its the earliest ancestor
 type CorD = (C|D) 
-```
-
-## Hierarchies in Types
-
-```
-   ┌───┐
-   │ I │
-   └─┬─┘
-  ┌──┴───┐
-┌─┴─┐  ┌─┴─┐
-│ A │  │ B │
-└───┘  └─┬─┘
-      ┌──┴───┐
-    ┌─┴─┐  ┌─┴─┐
-    │ C │  │ D │
-    └───┘  └───┘
-
 ```
 
 # Drawbacks


### PR DESCRIPTION
As requested by @dsyme on twitter. 

This adds an RFC for erased union types. First time here writing an RFC so might not have fully thought things through. 

The suggestion: https://github.com/fsharp/fslang-suggestions/issues/538 probably needs to be approved first. If everything is fine, happy to continue with the actual implementation.

[Rendered](https://github.com/swoorup/fslang-design/blob/master/RFCs/FS-1092-Erased-Union-Types.md)