### PR TITLE
minor suggested edits to recently edited RFC.

### DIFF
--- a/RFCs/FS-1097-task-builder.md
+++ b/RFCs/FS-1097-task-builder.md
@@ -9,7 +9,7 @@ The design suggestion [Native support for task { ... } ](https://github.com/fsha
 
 # Summary
 
-We add a `task { .. }` builder to the F# standard library, implemented using [resumable code](https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1087-resumable-code.md).
+We add a `task { .. }` builder to the F# standard library, implemented using [FS-1087 resumable code](https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1087-resumable-code.md).
 
 The design is heavily influenced by [TaskBuilder.fs](https://github.com/rspeele/TaskBuilder.fs/) and [Ply](https://github.com/crowded/ply) which effectively
 formed part of prototypes for this RFC (thank you!!!!)
@@ -32,7 +32,7 @@ We add support for tasks along the lines of `TaskBuilder.fs`.  This supports
 
 * `use` on both `IDisposable` and `IAsyncDisposable` resources
 
-* `backgroundTask { ... }` to escapte the UI thread synchronization context
+* `backgroundTask { ... }` to escape the UI thread synchronization context
 
 For example, a simple task:
 ```fsharp
@@ -162,7 +162,7 @@ A `vtask { ... }` is definable as a user-library using resumable code,  replicat
 
 ### IAsyncDisposable
 
-If `netstandard2.1` FSHarp.Core.dll or higher is referenced, then the following method is available directly on the TaskBuilder type:
+If `netstandard2.1` FSharp.Core.dll or higher is referenced, then the following method is available directly on the TaskBuilder type:
 
 ```fsharp
 type TaskBuilderBase =

--- a/RFCs/FS-1099-list-collector.md
+++ b/RFCs/FS-1099-list-collector.md
@@ -12,7 +12,9 @@ This RFC covers the detailed proposal for the resumable state machine support ne
 
 # Summary
 
-TBD
+Optimize runtime cost of list and array expressions. Those currently rely on the Sequence expression infrastructure.
+
+In conjunction with [FS-1087 resumable code](FS-1087-resumable-code.md), this open alley for performance gains.
 
 # Detailed Design 
 ```fsharp

--- a/RFCs/FS-1100-Printf-binary.md
+++ b/RFCs/FS-1100-Printf-binary.md
@@ -12,7 +12,7 @@ This RFC covers the detailed proposal for this suggestion.
 # Summary
 
 An additional format specifier `%B` will be added to F# which formats a basic integer type
-(currently (byte|int16|int32|int64|sbyte|uint16|uint32|uint64|nativeint|unativeint))
+(currently `byte`|`int16`|`int32`|`int64`|`sbyte`|`uint16`|`uint32`|`uint64`|`nativeint`|`unativeint`)
 as an unsigned binary number.
 
 # Motivation


### PR DESCRIPTION
additional-conversions: mostly formatting, reformulating a bullet list into better layout to convey the overall intent.

task-builder: add a link and fix typos

list-collector: define the summary

printf-binary: minor formatting