### PR TITLE
Update FS-1093-additional-conversions.md

### DIFF
--- a/RFCs/FS-1093-additional-conversions.md
+++ b/RFCs/FS-1093-additional-conversions.md
@@ -14,17 +14,19 @@ This RFC extends F# to include type-directed conversions when known type informa
 
 1. Puts in place a general backwards-compatible mechanism for type directed conversions (and one that works in conjunction with the existing techniques to allow subsumption at some specific places)
 
-2. Selects a particular set of type directed conversions to use.  These are currently
+2. Selects a particular set of type directed conversions to use.  These are:
    - the existing func (`'a -> 'b`) --> `delegate` type directed conversions
    - the existing `delegate` --> LINQ `Expression` type directed conversions
    - upcasting
-   - `int32` --> `int64`/`float64`
+   - `int32` --> `int64`/`nativeint`/`float64`
    - `op_Implicit` when both source and destination are nominal.
 
-3. Implements a warning when any of these are used (outside existing uses of upcasting). The warning is off by default for all but uses of F#-defined `op_Implicit`.
+3. Implements a warning when any of these are used (excluding the two existing conversions). The warning is off by default for all but uses of F#-defined `op_Implicit`.
 
 Type-directed conversions are used as an option of last resort, at leaf expressions, so different types
 may be returned on each bracnh of compound structures like `if .. then ... else`.
+
+Numeric an `op_Implicit` type-directed conversions only apply when both types are fully known, and are generally only useful for non-generic types.
 
 # Design Principles
 
@@ -44,7 +46,7 @@ The intent of this RFC is to give a user experience where:
 
 7. Inadvertent use of the mechanism should not introduce confusion or bugs
 
-8. The F# programmer is not encouraged to start adding `op_Implicit` conversions to their type designs
+8. The F# programmer is discouraged from starting adding `op_Implicit` conversions to their type designs
 
 NOTE: The aim is to make a feature which is trustworthy and barely noticed. It's not the sort of feature where you tell people "hey, go use this" - instead the aim is that you don't need to be cognisant of the feature when coding in F#, though you may end up using the mechanism when calling a library, or when coding with numeric data, or when using data supporting subtyping.  Technical knowledge of the feature is not intended to be part of the F# programmer's working knowledge, it's just something that makes using particular libraries nice and coding less irritating, without making it less safe.
 


### PR DESCRIPTION
This adjusts the RFC to take this part of the discussion into account. https://github.com/fsharp/fslang-design/discussions/525#discussioncomment-1051349

The aim is to discourage the definition of `op_Implicit` by the F# programmer through warnings whenever an F#-defined `op_Implicit` is used.  Thus an F# library writer wanting to use this has to both disable the warning (presumably after reading the linked guidance), and encourge users of the library to also disable the warning.


