### PR TITLE
Change status of the CE custom op overloads RFC to completed

### DIFF
--- a/FSharp-6.0/FS-1056-allow-custom-operation-overloads.md
+++ b/FSharp-6.0/FS-1056-allow-custom-operation-overloads.md
@@ -2,7 +2,7 @@
 
 
 * [Approved in principle](https://github.com/fsharp/fslang-suggestions/issues/69#issuecomment-388558877)
-* Implementation: [In Progress](https://github.com/dotnet/fsharp/pull/4949), [Part 2](https://github.com/dotnet/fsharp/pull/10171)
+* Implementation: [Completed](https://github.com/dotnet/fsharp/pull/4949), [Part 2](https://github.com/dotnet/fsharp/pull/10171)
 * Discussion: https://github.com/fsharp/fslang-design/issues/301
 
 # Summary


### PR DESCRIPTION
Click “Files changed” → “⋯” → “View file” for the rendered RFC.

The implementation is merged, so make it so!