### PR TITLE
RFC FS-1088: fix code example

### DIFF
--- a/RFCs/FS-1088-if-bang.md
+++ b/RFCs/FS-1088-if-bang.md
@@ -49,7 +49,7 @@ In other words, the following code:
 ```
 async {
     if! cexpr1 then expr1
-    else! cexpr2 then expr2
+    elif! cexpr2 then expr2
     else expr3
 }
 ```


### PR DESCRIPTION
`else!` isn't a construct proposed in this RFC, so I assume it should be replaced with `elif!`.