### PR TITLE
Improve signature of defaultWith

### DIFF
--- a/RFCs/FS-1123-result-module-parity-with-option.md
+++ b/RFCs/FS-1123-result-module-parity-with-option.md
@@ -53,7 +53,7 @@ Interface file:
     val defaultValue: value: 'T -> result: Result<'T, 'Error> -> 'T
 
     [<CompiledName("DefaultWith")>]
-    val defaultWith: defThunk: (unit -> 'T) -> result: Result<'T, 'Error> -> 'T
+    val defaultWith: defThunk: ('Error -> 'T) -> result: Result<'T, 'Error> -> 'T
 
     [<CompiledName("Count")>]
     val count: result: Result<'T, 'Error> -> int


### PR DESCRIPTION
Click “Files changed” → “⋯” → “View file” for the rendered RFC.

Based on @gusty suggestion to improve the defaultWith signature : 
See : https://github.com/fsharp/fslang-suggestions/issues/1123#issuecomment-1179171067
- Will give us the opportunity to use the error value in the compensation.