### PR TITLE
Rename string interpolation RFC

### DIFF
--- a/RFCs/FS-1131-better-interpolated-triple-quoted-strings.md
+++ b/RFCs/FS-1131-better-interpolated-triple-quoted-strings.md
@@ -1,4 +1,4 @@
-# F# RFC FS-1128 - Extended interpolation syntax for triple quoted string literals
+# F# RFC FS-1131 - Extended interpolation syntax for triple quoted string literals
 
 The design suggestion [Allow double dollar signs for interpolated strings as in C# 11](https://github.com/fsharp/fslang-suggestions/issues/1150) has been marked "approved in principle".
 

--- a/RFCs/FS-1132-better-interpolated-triple-quoted-strings.md
+++ b/RFCs/FS-1132-better-interpolated-triple-quoted-strings.md
@@ -1,4 +1,4 @@
-# F# RFC FS-1131 - Extended interpolation syntax for triple quoted string literals
+# F# RFC FS-1132 - Extended interpolation syntax for triple quoted string literals
 
 The design suggestion [Allow double dollar signs for interpolated strings as in C# 11](https://github.com/fsharp/fslang-suggestions/issues/1150) has been marked "approved in principle".
 


### PR DESCRIPTION
There were two FS-1128-... RFCs. Fixed by renaming the more recent one to FS-1132-...

Click “Files changed” → “⋯” → “View file” for the rendered RFC.
