### PR TITLE
Fix attribute placement

### DIFF
--- a/RFCs/FS-1011-warn-on-recursive-without-tail-call.md
+++ b/RFCs/FS-1011-warn-on-recursive-without-tail-call.md
@@ -62,8 +62,7 @@ let rec bar x =
         printfn "0x%08x" x
         bar (x - 1)     // OK: tail-recursive call.
         
-[<TailCall>]
-and baz x =
+and [<TailCall>] baz x =
     printfn "Baz!"
     bar (x - 1)         // OK: tail-recursive call.
 ```


### PR DESCRIPTION
Click “Files changed” → “⋯” → “View file” for the rendered RFC.

While working on https://github.com/dotnet/fsharp/pull/15260 I noticed that the example has the attribute at the wrong place.