### PR TITLE
initialize RFC-1137 Prefer extension method over property when arguments are provided

### DIFF
--- a/preview/FS-1137-prefer-extensions-method-over-property-when-arguments-provided.md
+++ b/preview/FS-1137-prefer-extensions-method-over-property-when-arguments-provided.md
@@ -1,0 +1,22 @@
+# F# RFC FS-1137 - Prefer extension method over intrinsic property when arguments are provided
+* [x] Approved in principle
+* [x] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/1039)
+* [x] Implementation: [In progress](https://github.com/dotnet/fsharp/pull/16032)
+* [x] [Discussion](https://github.com/fsharp/fslang-design/discussions/752)
+
+# Summary
+
+# Motivation
+
+# Detailed design
+
+## Implementation details
+
+## Documentation
+
+# Drawbacks
+
+# Alternatives
+
+# Unresolved questions
+


### PR DESCRIPTION
Click “Files changed” → “⋯” → “View file” for the rendered RFC.

Just a place holder for now, in order to have all links setup (https://github.com/fsharp/fslang-design/discussions/752).