### PR TITLE
Update FS-1079-union-properties-visible   => members to be created even when union has signature files

### DIFF
--- a/RFCs/FS-1079-union-properties-visible.md
+++ b/RFCs/FS-1079-union-properties-visible.md
@@ -101,6 +101,7 @@ type Example =
    private to Foo and Bar.
 
 2. If a union type is in a file with a signature, that signature can entirely hide the representation of the union type, and yet still individually reveal the individual IsFoo, IsBar members.  (Other generated members not covered by this RFC can't be individually revealed like this.)
+   When using signature files, the individual IsFoo,IsBar members are automatically exposed and available on IL level (as before) as well as for F# code (addition).
 
 # Drawbacks
 


### PR DESCRIPTION
Click “Files changed” → “⋯” → “View file” for the rendered RFC.


After the implementation of FS-1079 was merged in, @KevinRansom  and I independently observed a failure in the compiler codebase when using a freshly built compiler with preview features on.
Important to note, this FS-1079 was not actively used anywhere.

What happened is that unpickling metadata from the built Fsharp.Compiler.Service.dll failed when encountering a combination of:
- Discriminated union
- In a signature file
- In a module rec
- Signature file was not exposing the .Is* testers in any way
- Consumed from a different file which inline the usage

The usage of that type from a different type meant using type information from the signature file.
The resulting error was a general unpickling failure (".. error at node 6652") which only after rebuilding the compiler from scratch lead to the discovery of a union in module rec in .fsi undere that ID.

I believe the fix in https://github.com/dotnet/fsharp/pull/16657 is good, but we must acknowledge that the .fsi files will now expose the .Is* testers even for F# consumers, not just on IL level.