### PR TITLE
Add prior art & interop sections to RFC template

### DIFF
--- a/RFC_template.md
+++ b/RFC_template.md
@@ -39,6 +39,10 @@ Why should we *not* do this?
 
 What other designs have been considered? What is the impact of not doing this?
 
+# Prior art
+
+Has a similar feature been proposed or implemented for other programming languages (e.g., [C#](https://github.com/dotnet/csharplang), [OCaml](https://github.com/ocaml/RFCs), etc.)? Is there any wisdom to be gained from these proposals, designs, implementations, or from real-world usage?
+
 # Compatibility
 
 Please address all necessary compatibility questions:
@@ -47,6 +51,11 @@ Please address all necessary compatibility questions:
 * What happens when previous versions of the F# compiler encounter this design addition as source code?
 * What happens when previous versions of the F# compiler encounter this design addition in compiled binaries?
 * If this is a change or extension to FSharp.Core, what happens when previous versions of the F# compiler encounter this construct?
+
+# Interop
+
+* What happens when this feature is consumed by another .NET language?
+* Are there any planned or proposed features for another .NET language (e.g., [C#](https://github.com/dotnet/csharplang)) that we would want this feature to interoperate with?
 
 # Pragmatics
 


### PR DESCRIPTION
This PR adds "prior art" & "interop" sections to the RFC template. While I don't think we should always feel constrained by prior art or interop, I think it wouldn't hurt to have a reminder to consider them when it makes sense.

If we don't think they deserve their own sections, they could be moved under "detailed design" instead. I'm open to suggestions for improving the wording, etc.