### PR TITLE
Update implementation link in FS-1095 RFC

### DIFF
--- a/drafts/FS-1095-requirenamedargumentattribute.md
+++ b/drafts/FS-1095-requirenamedargumentattribute.md
@@ -8,7 +8,7 @@ This RFC covers the detailed proposal for this suggestion.
 
 - [x] Approved in principle
 - [x] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/414)
-- [x] [Implementation](https://github.com/dotnet/fsharp/pull/11368)
+- [x] [Implementation](https://github.com/dotnet/fsharp/pull/20340)
 - [ ] Design Review Meeting(s) with @dsyme and others invitees
 - [x] [Discussion](https://github.com/fsharp/fslang-design/discussions/538)
 

--- a/drafts/FS-1095-requirenamedargumentattribute.md
+++ b/drafts/FS-1095-requirenamedargumentattribute.md
@@ -10,7 +10,8 @@ This RFC covers the detailed proposal for this suggestion.
 - [x] [Suggestion](https://github.com/fsharp/fslang-suggestions/issues/414)
 - [x] [Implementation](https://github.com/dotnet/fsharp/pull/20340)
 - [ ] Design Review Meeting(s) with @dsyme and others invitees
-- [x] [Discussion](https://github.com/fsharp/fslang-design/discussions/538)
+- [x] [F# Language Design Discussion](https://github.com/fsharp/fslang-design/discussions/538)
+- [x] [Dotnet Runtime Discussion](https://github.com/dotnet/runtime/issues/51451)
 
 # Summary
 


### PR DESCRIPTION
fix the PR link.

Click “Files changed” → “⋯” → “View file” for the rendered RFC.
